### PR TITLE
make numpy min version 1.18.1 instead of pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           architecture: 'x64'
       - name: Install dependencies
         run: |
-          pip install nose
+          pip install nose coverage
           pip install -e .
       - name: Test
         run: nosetests stl_tools --with-coverage --cover-package=stl_tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           pip install nose
       - name: Test
-        run: nosetests3 stl_tools --with-coverage --cover-package=stl_tools
+        run: nosetests stl_tools --with-coverage --cover-package=stl_tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install nose
+          pip install -e .
       - name: Test
         run: nosetests stl_tools --with-coverage --cover-package=stl_tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+        id: checkout
+      - uses: actions/setup-python@v2
+        name: Install Python 3.8
+        with:
+          python-version: '3.8'
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          pip install nose
+      - name: Test
+        run: nosetests3 stl_tools --with-coverage --cover-package=stl_tools

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ ext_1 = Extension(SRC_DIR + ".cwrapped",
 EXTENSIONS = [ext_1]
 
 setup(name='stl_tools',
-      version='0.4.1',
+      version='0.4.2',
       install_requires=[
-        'numpy==1.18.1',
+        'numpy>=1.18.1',
         'scipy',
         'matplotlib'],
       description="Generate STL files from numpy arrays and text",


### PR DESCRIPTION
Using poetry helped determine this fix.

Also add CI to show this change works:
```
$ nosetests3 stl_tools --with-coverage --cover-package=stl_tools
....
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
stl_tools/__init__.py        2      0   100%
stl_tools/numpy2stl.py     105     33    69%   6, 60, 111, 115-121, 158-188, 192, 196, 200
stl_tools/text2png.py       18      0   100%
------------------------------------------------------
TOTAL                      125     33    74%
----------------------------------------------------------------------
Ran 4 tests in 1.126s

OK
```